### PR TITLE
[feat] 整合首頁和接案者頁面

### DIFF
--- a/pages/templates/pages/home.html
+++ b/pages/templates/pages/home.html
@@ -5,7 +5,7 @@
 <html lang="en">
   <body class="bg-white">
     <!-- 最近新增 -->
-    <div class="main overflow-hidden flex flex-col justify-between bg-gray-200"> 
+    <div class="main overflow-hidden flex flex-col justify-between bg-white"> 
       <div class="visualBox pt-3 pb-3 my-5 w-full sm:max-w-[600px] md:max-w-[800px] lg:max-w-[1200px] mx-auto bg-gray-200 rounded-md shadow-md">
         <h1 class="text-xl font-bold text-gray-700 mb-4">最近新增</h1>
         <div class="services grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -17,8 +17,9 @@
         </div>
       </div>
     </div>
-    <!-- 您可能會感興趣 -->
-    <div class="main overflow-hidden flex flex-col justify-between bg-gray-200"> 
+
+        <!-- 您可能會感興趣 -->
+    <div class="main overflow-hidden flex flex-col justify-between bg-white"> 
       <div class="visualBox pt-3 pb-3 my-5 w-full sm:max-w-[600px] md:max-w-[800px] lg:max-w-[1200px] mx-auto bg-gray-200 rounded-md shadow-md">
         <h1 class="text-xl font-bold text-gray-700 mb-4">您可能會感興趣</h1>
         <div class="services grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -30,8 +31,8 @@
         </div>
       </div>
     </div>
-    <!-- 評分最高 -->
-    <div class="main overflow-hidden flex flex-col justify-between bg-gray-200"> 
+        <!-- 評分最高 -->
+    <div class="main overflow-hidden flex flex-col justify-between bg-white"> 
       <div class="visualBox pt-3 pb-3 my-5 w-full sm:max-w-[600px] md:max-w-[800px] lg:max-w-[1200px] mx-auto bg-gray-200 rounded-md shadow-md">
         <h1 class="text-xl font-bold text-gray-700 mb-4">評分最高</h1>
         <div class="services grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">

--- a/pages/templates/pages/home.html
+++ b/pages/templates/pages/home.html
@@ -4,351 +4,42 @@
 <!DOCTYPE html>
 <html lang="en">
   <body class="bg-white">
-    <!-- 搜尋後顯示 -->
-    <div class="main ">
-      <div
-        class="visualBox flex justify-center pt-3 pb-3 my-5 w-full sm:max-w-[600px] md:max-w-[800px] lg:max-w-[1200px] mx-auto bg-gray-200 rounded-md shadow-md"
-      >
-        <div class="flex gap-10">
-          <a href="" target="_blank">
-            <div class="item transition-transform duration-300 hover:scale-105">
-              <img class="taskeradvertise" src= "{% static 'images/webdev.png' %}" />
-              <div class="pt-1">
-                <div class="flex">
-                  <img class="avatarInpage" src="{% static 'images/kao.jpg' %}" alt="" />
-                  <p class="pt-3.5 pl-1">龍哥團隊</p>
-                </div>
-                <p class="max-w-[250px]">
-                  I will do frontend and backend in django as full stack
-                  developer
-                </p>
-                <div class="flex">
-                  <div class="relative w-5 h-5">
-                    <div
-                      class="absolute w-full h-full bg-black clip-star"
-                    ></div>
-                  </div>
-                  <p class="text-gray-500">(5.0)</p>
-                </div>
-                <p class="text-left">from US$999</p>
-              </div>
-            </div>
-          </a>
-          <a href="" target="_blank">
-            <div class="item transition-transform duration-300 hover:scale-105">
-              <img
-                class="taskeradvertise"
-                src="{% static 'images/webdev2.png' %}"
-              />
-              <div class="pt-1">
-                <div class="flex">
-                  <img class="avatarInpage" src="{% static 'images/pika.jpg' %}" alt="" />
-                  <p class="pt-3.5 pl-1">皮卡丘聯盟</p>
-                </div>
-                <p class="max-w-[250px]">
-                  I will do frontend and backend in django as full stack
-                  developer
-                </p>
-                <div class="flex">
-                  <div class="relative w-5 h-5">
-                    <div
-                      class="absolute w-full h-full bg-black clip-star"
-                    ></div>
-                  </div>
-                  <p class="text-gray-500">(4.7)</p>
-                </div>
-                <p class="text-left">from US$799</p>
-              </div>
-            </div>
-          </a>
-          <a href="" target="_blank">
-            <div class="item transition-transform duration-300 hover:scale-105">
-              <img
-                class="taskeradvertise"
-                src="{% static 'images/webdev3.jpg' %}"
-              />
-              <div class="pt-1">
-                <div class="flex">
-                  <img class="avatarInpage" src="{% static 'images/ufo.jpg' %}" alt="" />
-                  <p class="pt-3.5 pl-1">老高ufo說書</p>
-                </div>
-                <p class="max-w-[250px]">
-                  I will do frontend and backend in django as full stack
-                  developer
-                </p>
-                <div class="flex">
-                  <div class="relative w-5 h-5">
-                    <div
-                      class="absolute w-full h-full bg-black clip-star"
-                    ></div>
-                  </div>
-                  <p class="text-gray-500">(4.8)</p>
-                </div>
-                <p class="text-left">from US$299</p>
-              </div>
-            </div>
-          </a>
-          <a href="" target="_blank">
-            <div class="item transition-transform duration-300 hover:scale-105">
-              <img
-                class="taskeradvertise"
-                src="{% static 'images/webdev4.jpg' %}"
-              />
-              <div class="pt-1">
-                <div class="flex">
-                  <img
-                    class="avatarInpage"
-                    src="{% static 'images/redgirl.webp' %}"
-                    alt=""
-                  />
-                  <p class="pt-3.5 pl-1">聖誕鄰居小姊姊</p>
-                </div>
-                <p class="max-w-[250px]">
-                  I will do frontend and backend in django as full stack
-                  developer
-                </p>
-                <div class="flex">
-                  <div class="relative w-5 h-5">
-                    <div
-                      class="absolute w-full h-full bg-black clip-star"
-                    ></div>
-                  </div>
-                  <p class="text-gray-500">(3.9)</p>
-                </div>
-                <p class="text-left">from US$599</p>
-              </div>
-            </div>
-          </a>
+    <!-- 最近新增 -->
+    <div class="main overflow-hidden flex flex-col justify-between bg-gray-200"> 
+      <div class="visualBox pt-3 pb-3 my-5 w-full sm:max-w-[600px] md:max-w-[800px] lg:max-w-[1200px] mx-auto bg-gray-200 rounded-md shadow-md">
+        <h1 class="text-xl font-bold text-gray-700 mb-4">最近新增</h1>
+        <div class="services grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          {% for service in services %}
+          {% include "pages/service_card.html" %}
+          {% empty %}
+          <p class="text-center text-gray-500 col-span-full">目前沒有服務資料。</p>
+          {% endfor %}
         </div>
       </div>
-      <div
-        class="visualBox flex justify-center pt-3 pb-3 my-5 w-full sm:max-w-[600px] md:max-w-[800px] lg:max-w-[1200px] mx-auto bg-gray-200 rounded-md shadow-md"
-      >
-        <div class="flex gap-10">
-          <a href="" target="_blank">
-            <div class="item transition-transform duration-300 hover:scale-105">
-              <img class="taskeradvertise" src="{% static 'images/webdev.png'%}" />
-              <div class="pt-1">
-                <div class="flex">
-                  <img class="avatarInpage" src="{% static 'images/kao.jpg' %}" alt="" />
-                  <p class="pt-3.5 pl-1">龍哥團隊</p>
-                </div>
-                <p class="max-w-[250px]">
-                  I will do frontend and backend in django as full stack
-                  developer
-                </p>
-                <div class="flex">
-                  <div class="relative w-5 h-5">
-                    <div
-                      class="absolute w-full h-full bg-black clip-star"
-                    ></div>
-                  </div>
-                  <p class="text-gray-500">(5.0)</p>
-                </div>
-                <p class="text-left">from US$999</p>
-              </div>
-            </div>
-          </a>
-          <a href="" target="_blank">
-            <div class="item transition-transform duration-300 hover:scale-105">
-              <img
-                class="taskeradvertise"
-                src="{% static 'images/webdev2.png' %}"
-              />
-              <div class="pt-1">
-                <div class="flex">
-                  <img class="avatarInpage" src="{% static 'images/pika.jpg' %}" alt="" />
-                  <p class="pt-3.5 pl-1">皮卡丘聯盟</p>
-                </div>
-                <p class="max-w-[250px]">
-                  I will do frontend and backend in django as full stack
-                  developer
-                </p>
-                <div class="flex">
-                  <div class="relative w-5 h-5">
-                    <div
-                      class="absolute w-full h-full bg-black clip-star"
-                    ></div>
-                  </div>
-                  <p class="text-gray-500">(4.7)</p>
-                </div>
-                <p class="text-left">from US$799</p>
-              </div>
-            </div>
-          </a>
-          <a href="" target="_blank">
-            <div class="item transition-transform duration-300 hover:scale-105">
-              <img
-                class="taskeradvertise"
-                src="{% static 'images/webdev3.jpg' %}"
-              />
-              <div class="pt-1">
-                <div class="flex">
-                  <img class="avatarInpage" src="{% static 'images/ufo.jpg' %}" alt="" />
-                  <p class="pt-3.5 pl-1">老高ufo說書</p>
-                </div>
-                <p class="max-w-[250px]">
-                  I will do frontend and backend in django as full stack
-                  developer
-                </p>
-                <div class="flex">
-                  <div class="relative w-5 h-5">
-                    <div
-                      class="absolute w-full h-full bg-black clip-star"
-                    ></div>
-                  </div>
-                  <p class="text-gray-500">(4.8)</p>
-                </div>
-                <p class="text-left">from US$299</p>
-              </div>
-            </div>
-          </a>
-          <a href="" target="_blank">
-            <div class="item transition-transform duration-300 hover:scale-105">
-              <img
-                class="taskeradvertise"
-                src="{% static 'images/webdev4.jpg' %}"
-              />
-              <div class="pt-1">
-                <div class="flex">
-                  <img
-                    class="avatarInpage"
-                    src="{% static 'images/redgirl.webp' %}"
-                    alt=""
-                  />
-                  <p class="pt-3.5 pl-1">聖誕鄰居小姊姊</p>
-                </div>
-                <p class="max-w-[250px]">
-                  I will do frontend and backend in django as full stack
-                  developer
-                </p>
-                <div class="flex">
-                  <div class="relative w-5 h-5">
-                    <div
-                      class="absolute w-full h-full bg-black clip-star"
-                    ></div>
-                  </div>
-                  <p class="text-gray-500">(3.9)</p>
-                </div>
-                <p class="text-left">from US$599</p>
-              </div>
-            </div>
-          </a>
+    </div>
+    <!-- 您可能會感興趣 -->
+    <div class="main overflow-hidden flex flex-col justify-between bg-gray-200"> 
+      <div class="visualBox pt-3 pb-3 my-5 w-full sm:max-w-[600px] md:max-w-[800px] lg:max-w-[1200px] mx-auto bg-gray-200 rounded-md shadow-md">
+        <h1 class="text-xl font-bold text-gray-700 mb-4">您可能會感興趣</h1>
+        <div class="services grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          {% for service in services %}
+          {% include "pages/service_card.html" %}
+          {% empty %}
+          <p class="text-center text-gray-500 col-span-full">目前沒有服務資料。</p>
+          {% endfor %}
         </div>
       </div>
-      <div
-        class="visualBox flex justify-center pt-3 pb-3 my-5 w-full sm:max-w-[600px] md:max-w-[800px] lg:max-w-[1200px] mx-auto bg-gray-200 rounded-md shadow-md"
-      >
-        <div class="flex gap-10">
-          <a href="" target="_blank">
-            <div class="item transition-transform duration-300 hover:scale-105">
-              <img class="taskeradvertise" src="{% static 'images/webdev.png' %}" />
-              <div class="pt-1">
-                <div class="flex">
-                  <img class="avatarInpage" src="{% static 'images/kao.jpg' %}" alt="" />
-                  <p class="pt-3.5 pl-1">龍哥團隊</p>
-                </div>
-                <p class="max-w-[250px]">
-                  I will do frontend and backend in django as full stack
-                  developer
-                </p>
-                <div class="flex">
-                  <div class="relative w-5 h-5">
-                    <div
-                      class="absolute w-full h-full bg-black clip-star"
-                    ></div>
-                  </div>
-                  <p class="text-gray-500">(5.0)</p>
-                </div>
-                <p class="text-left">from US$999</p>
-              </div>
-            </div>
-          </a>
-          <a href="" target="_blank">
-            <div class="item transition-transform duration-300 hover:scale-105">
-              <img
-                class="taskeradvertise"
-                src="{% static 'images/webdev2.png'%}"
-              />
-              <div class="pt-1">
-                <div class="flex">
-                  <img class="avatarInpage" src="{% static 'images/pika.jpg' %}" alt="" />
-                  <p class="pt-3.5 pl-1">皮卡丘聯盟</p>
-                </div>
-                <p class="max-w-[250px]">
-                  I will do frontend and backend in django as full stack
-                  developer
-                </p>
-                <div class="flex">
-                  <div class="relative w-5 h-5">
-                    <div
-                      class="absolute w-full h-full bg-black clip-star"
-                    ></div>
-                  </div>
-                  <p class="text-gray-500">(4.7)</p>
-                </div>
-                <p class="text-left">from US$799</p>
-              </div>
-            </div>
-          </a>
-          <a href="" target="_blank">
-            <div class="item transition-transform duration-300 hover:scale-105">
-              <img
-                class="taskeradvertise"
-                src="{% static 'images/webdev3.jpg'%}"
-              />
-              <div class="pt-1">
-                <div class="flex">
-                  <img class="avatarInpage" src="{% static 'images/ufo.jpg' %}" alt="" />
-                  <p class="pt-3.5 pl-1">老高ufo說書</p>
-                </div>
-                <p class="max-w-[250px]">
-                  I will do frontend and backend in django as full stack
-                  developer
-                </p>
-                <div class="flex">
-                  <div class="relative w-5 h-5">
-                    <div
-                      class="absolute w-full h-full bg-black clip-star"
-                    ></div>
-                  </div>
-                  <p class="text-gray-500">(4.8)</p>
-                </div>
-                <p class="text-left">from US$299</p>
-              </div>
-            </div>
-          </a>
-          <a href="" target="_blank">
-            <div class="item transition-transform duration-300 hover:scale-105">
-              <img
-                class="taskeradvertise"
-                src="{% static 'images/webdev4.jpg' %}"
-              />
-              <div class="pt-1">
-                <div class="flex">
-                  <img
-                    class="avatarInpage"
-                    src="{% static 'images/redgirl.webp' %}"
-                    alt=""
-                  />
-                  <p class="pt-3.5 pl-1">聖誕鄰居小姊姊</p>
-                </div>
-                <p class="max-w-[250px]">
-                  I will do frontend and backend in django as full stack
-                  developer
-                </p>
-                <div class="flex">
-                  <div class="relative w-5 h-5">
-                    <div
-                      class="absolute w-full h-full bg-black clip-star"
-                    ></div>
-                  </div>
-                  <p class="text-gray-500">(3.9)</p>
-                </div>
-                <p class="text-left">from US$599</p>
-              </div>
-            </div>
-          </a>
+    </div>
+    <!-- 評分最高 -->
+    <div class="main overflow-hidden flex flex-col justify-between bg-gray-200"> 
+      <div class="visualBox pt-3 pb-3 my-5 w-full sm:max-w-[600px] md:max-w-[800px] lg:max-w-[1200px] mx-auto bg-gray-200 rounded-md shadow-md">
+        <h1 class="text-xl font-bold text-gray-700 mb-4">評分最高</h1>
+        <div class="services grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          {% for service in services %}
+          {% include "pages/service_card.html" %}
+          {% empty %}
+          <p class="text-center text-gray-500 col-span-full">目前沒有服務資料。</p>
+          {% endfor %}
         </div>
       </div>
     </div>
@@ -414,7 +105,7 @@
           <a href="" target="_blank">
             <div class="item">
               <div class="flex justify-between items-center">
-                <img class="logosize" src="{% static 'images/logo-1.jpg' %}" alt=""/>
+                <img class="logosize" src="{% static 'images/logo-1.jpg' %}" alt="" />
                 <p class="text-4xl font-bold pl-1 py-7 text-right">Pizza宵夜聯盟</p>
                 <!-- 愛心組件 -->
                 <div class="flex">
@@ -468,7 +159,7 @@
         <a href="" target="_blank">
           <div class="item">
             <div class="flex justify-between items-center">
-              <img class="logosize" src="{% static 'images/logo-2.png' %}" alt=""/>
+              <img class="logosize" src="{% static 'images/logo-2.png' %}" alt="" />
               <p class="text-4xl font-bold pl-1 py-7 text-right">肯德基炸雞聯盟</p>
               <!-- 愛心組件 -->
               <div class="flex">
@@ -522,79 +213,42 @@
      <!-- 愛心js -->
     <script>
       // 取得按鈕元素
-      const heartButton = document.getElementById("heartButton");
-    
-      // 點擊事件
-      heartButton.addEventListener("click", (event) => {
-        event.preventDefault(); // 防止預設行為（例如表單提交或刷新）
-        const isActive = heartButton.getAttribute("data-active") === "true";
-    
-        // 更新按鈕的狀態屬性
-        heartButton.setAttribute("data-active", !isActive);
-    
-        // 切換樣式
-        if (isActive) {
-          heartButton
-            .querySelector("svg")
-            .classList.remove("text-red-500");
-          heartButton
-            .querySelector("svg")
-            .classList.add("text-gray-400");
-        } else {
-          heartButton
-            .querySelector("svg")
-            .classList.remove("text-gray-400");
-          heartButton
-            .querySelector("svg")
-            .classList.add("text-red-500");
-        }
+      document.querySelectorAll(".heartframe button").forEach((button) => {
+        button.addEventListener("click", (event) => {
+          event.preventDefault(); // 防止預設行為
+          const isActive = button.getAttribute("data-active") === "true";
+
+          // 更新按鈕的狀態屬性
+          button.setAttribute("data-active", !isActive);
+
+          // 切換樣式
+          if (isActive) {
+            button.querySelector("svg").classList.remove("text-red-500");
+            button.querySelector("svg").classList.add("text-gray-400");
+          } else {
+            button.querySelector("svg").classList.remove("text-gray-400");
+            button.querySelector("svg").classList.add("text-red-500");
+          }
+        });
       });
     </script>
   </body>
-  <!-- 換頁按鈕 -->
+
+  <!-- 分頁按鈕 -->
   <div class="pagination justify-center pb-2">
-    <button class="new" id="prev" disabled>←</button>
-    <button class="new page" data-page="1">1</button>
-    <button class="new page" data-page="2">2</button>
-    <button class="new page" data-page="3">3</button>
-    <button class="new page" data-page="4">4</button>
-    <button class="new page" data-page="5">5</button>
-    <button class="new page" data-page="6">6</button>
-    <button class="new" id="next">→</button>
+    {% if page_obj.has_previous %}
+    <a class="new" href="?page={{ page_obj.previous_page_number }}">←</a>
+    {% endif %}
+
+    {% for num in page_obj.paginator.page_range %}
+    <a class="new page {% if num == page_obj.number %}active{% endif %}" href="?page={{ num }}">
+      {{ num }}
+    </a>
+    {% endfor %}
+
+    {% if page_obj.has_next %}
+    <a class="new" href="?page={{ page_obj.next_page_number }}">→</a>
+    {% endif %}
   </div>
-
-  <script>
-    const prevButton = document.getElementById("prev");
-    const nextButton = document.getElementById("next");
-    const pageButtons = document.querySelectorAll(".page");
-
-    let currentPage = 1;
-    const totalPages = 6;
-
-    function updateButtons() {
-      pageButtons.forEach(button => {
-          button.classList.toggle("active", button.dataset.page == currentPage);
-      });
-      prevButton.disabled = currentPage === 1;
-      nextButton.disabled = currentPage === totalPages;
-    }
-    pageButtons.forEach(button => {
-      button.addEventListener("click", () => {
-      currentPage = parseInt(button.dataset.page);
-      updateButtons();
-    });
-  });
-
-  prevButton.addEventListener("click", () => {
-      if (currentPage > 1) currentPage--;
-      updateButtons();
-  });
-
-  nextButton.addEventListener("click", () => {
-      if (currentPage < totalPages) currentPage++;
-      updateButtons();
-  });
-  updateButtons();
-  </script>
 </html>
-{% endblock  %}
+{% endblock %}

--- a/pages/templates/pages/service_card.html
+++ b/pages/templates/pages/service_card.html
@@ -9,10 +9,10 @@
       <div class="flex items-center mb-3">
         <img
           class="avatarInpage w-10 h-10 rounded-full border border-gray-300"
-          src="{% if user.profile.photo %}{{ user.profile.photo.url }}{% else %}https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp{% endif %}"
+          src="{% if service.freelancer_user.profile.photo %}{{ service.freelancer_user.profile.photo.url }}{% else %}https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp{% endif %}"
           alt="User Avatar"
         />
-        <p class="ml-3 text-sm font-semibold text-gray-700">{{ service.user.username }}</p>
+        <p class="ml-3 text-sm font-semibold text-gray-700">{{ service.freelancer_user.username }}</p>
       </div>
       <p class="text-gray-800 font-medium truncate" title="{{ service.title }}">{{ service.title }}</p>
       <div class="flex items-center mt-2">

--- a/pages/templates/pages/service_card.html
+++ b/pages/templates/pages/service_card.html
@@ -1,0 +1,27 @@
+<a href="" target="_blank" class="block">
+  <div class="item bg-white rounded-lg shadow-lg overflow-hidden border border-gray-300 hover:shadow-xl transition-transform duration-300 hover:scale-105">
+    <img
+      class="w-full h-48 object-cover"
+      src="{% if service.photo %}{{ service.photo.url }}{% else %}https://fakeimg.pl/300{% endif %}"
+      alt="Service Photo"
+    />
+    <div class="p-4">
+      <div class="flex items-center mb-3">
+        <img
+          class="avatarInpage w-10 h-10 rounded-full border border-gray-300"
+          src="{% if user.profile.photo %}{{ user.profile.photo.url }}{% else %}https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp{% endif %}"
+          alt="User Avatar"
+        />
+        <p class="ml-3 text-sm font-semibold text-gray-700">{{ service.user.username }}</p>
+      </div>
+      <p class="text-gray-800 font-medium truncate" title="{{ service.title }}">{{ service.title }}</p>
+      <div class="flex items-center mt-2">
+        <div class="relative w-5 h-5">
+          <div class="absolute w-full h-full bg-black clip-star"></div>
+        </div>
+        <p class="ml-2 text-sm text-gray-500">(4.8)</p>
+      </div>
+      <p class="mt-2 text-sm font-semibold text-blue-600">from US$1000000</p>
+    </div>
+  </div>
+</a>

--- a/pages/views.py
+++ b/pages/views.py
@@ -1,18 +1,15 @@
 from django.shortcuts import render
-
+from services.models import Service  
 
 def home(request):
-    return render(request, "pages/home.html")
-
+    services = Service.objects.order_by("-created_at")[:4]  
+    return render(request, "pages/home.html", {"services": services})
 
 def portfolio_showcase(request):
     return render(request, "pages/portfolio_showcase.html")
 
-
 def client(request):
     return render(request, "pages/client.html")
 
-
 def freelancer(request):
     return render(request, "pages/freelancer.html")
-

--- a/services/templates/services/create_service.html
+++ b/services/templates/services/create_service.html
@@ -29,15 +29,13 @@
         class="bg-white text-gray-800 border border-gray-300 rounded-md p-2 w-5/5 h-32"
         placeholder="請以文字描述您擅長的的技能"
       >
-{{ form.description.value|default_if_none:'' }}</textarea
-      >
+{{ form.description.value|default_if_none:'' }}</textarea>
       {% if form.description.errors %}
       <p class="text-red-500 text-sm">{{ form.description.errors }}</p>
       {% endif %}
     </div>
 
     <!-- Category Field -->
-
     <div class="flex flex-col space-y-2">
       <label for="category" class="text-gray-700 font-medium">分類：</label>
       <select
@@ -47,7 +45,7 @@
       >
         <option value="" selected>請選擇</option>
         {% for category in categories %}
-        <option value="{{ category.id }}">{{ category.name }}</option>
+        <option value="{{ category.id }}" {% if form.category.value == category.id %} selected {% endif %}>{{ category.name }}</option>
         {% endfor %}
       </select>
       {% if form.category.errors %}

--- a/services/templates/services/freelancer_dashboard.html
+++ b/services/templates/services/freelancer_dashboard.html
@@ -1,21 +1,35 @@
 {% extends "shared/layout.html" %} {% block "content" %} {% load static %}
 
 <div class="w-4/5 mx-auto my-8 bg-blue-100 p-6 rounded-lg shadow-md">
-  <!-- 新增服務按鈕 -->
-  <a
-    class="add-service-btn bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-6 inline-block"
-    href="{% url 'services:create_service' id=request.user.id %}"
-  >
-    新增服務
-  </a>
+    <!-- 按鈕區域 -->
+    <div class="flex justify-between items-center mb-6">
+      <!-- 上一頁 -->
+      <a
+        class="bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 px-4 rounded"
+        href="javascript:history.back()"
+      >
+        上一頁
+      </a>
 
-  <!-- 管理個人服務按鈕 -->
-  <button
-    id="toggle-management-btn"
-    class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded mb-6 ml-4"
-  >
-    管理個人服務
-  </button>
+      <!-- 右側按鈕區域 -->
+      <div class="flex space-x-4">
+        <!-- 新增服務按鈕 -->
+        <a
+          class="add-service-btn bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+          href="{% url 'services:create_service' id=request.user.id %}"
+        >
+          新增服務
+        </a>
+
+        <!-- 管理個人服務按鈕 -->
+        <button
+          id="toggle-management-btn"
+          class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded"
+        >
+          管理個人服務
+        </button>
+      </div>
+    </div>
 
   <div class="services grid grid-cols-1 md:grid-cols-4 gap-6">
     {% if services %} {% for service in services %}

--- a/services/views.py
+++ b/services/views.py
@@ -55,6 +55,7 @@ def create_service(request, id):
     )
 
 
+
 @login_required
 def edit_service(request, id, service_id):
     if not has_permission(request, id):

--- a/users/templates/users/client_dashboard.html
+++ b/users/templates/users/client_dashboard.html
@@ -19,6 +19,15 @@
             >更新個人資料</a
           >
         </li>
+        <li>
+          <a
+            href="{% url 'services:freelancer_dashboard' id=request.user.id %}"
+            class="hover:bg-blue-100 rounded-lg"
+          >
+            個人服務管理 (新增/修改)
+          </a>
+        </li>
+
         <li><a href="#" class="hover:bg-blue-100 rounded-lg">發包進度</a></li>
         <li><a href="#" class="hover:bg-blue-100 rounded-lg">評價與回饋</a></li>
         <li><a href="#" class="hover:bg-blue-100 rounded-lg">財務管理</a></li>

--- a/users/templates/users/client_dashboard.html
+++ b/users/templates/users/client_dashboard.html
@@ -19,14 +19,7 @@
             >更新個人資料</a
           >
         </li>
-        <li>
-          <a
-            href="{% url 'services:freelancer_dashboard' id=request.user.id %}"
-            class="hover:bg-blue-100 rounded-lg"
-          >
-            個人服務管理 (新增/修改)
-          </a>
-        </li>
+
 
         <li><a href="#" class="hover:bg-blue-100 rounded-lg">發包進度</a></li>
         <li><a href="#" class="hover:bg-blue-100 rounded-lg">評價與回饋</a></li>

--- a/users/templates/users/freelancer_dashboard.html
+++ b/users/templates/users/freelancer_dashboard.html
@@ -19,6 +19,14 @@
             >更新個人資料</a
           >
         </li>
+        <li>
+          <a
+            href="{% url 'services:freelancer_dashboard' id=request.user.id %}"
+            class="hover:bg-blue-100 rounded-lg"
+          >
+            個人服務管理 (新增/修改)
+          </a>
+        </li>
         <li><a href="#" class="hover:bg-blue-100 rounded-lg">發包進度</a></li>
         <li><a href="#" class="hover:bg-blue-100 rounded-lg">評價與回饋</a></li>
         <li><a href="#" class="hover:bg-blue-100 rounded-lg">財務管理</a></li>


### PR DESCRIPTION
本次pr更新部分為:
1) 測試到接案者頁面上傳服務作品後是否可以同時更新在首頁
2) 將原本首頁的卡牌改成for迴圈方式, 同時將卡牌html部分拉出來獨立變成一個檔 (名稱service_card.html)

step 1) 點選右上個人資料
![image](https://github.com/user-attachments/assets/63efe9cf-eaa0-45bd-a89c-3c1a7a815761)
step 2) 點選左下"轉換成接案者"
![image](https://github.com/user-attachments/assets/2a8907f7-f627-4839-af6d-e34b09e9caaf)
step 3) 點選"個人服務管理"
![image](https://github.com/user-attachments/assets/739414df-ae65-4269-82fe-d546e18bd4aa)
step 4) 新增服務後回到首頁, 會看到其他人新增的服務和自己剛新增的服務
![image](https://github.com/user-attachments/assets/b5b67337-2ed8-4229-afce-2fcced2a55c8)
(p.s. 圖片點進去還沒有跳轉是正常的)

