### PR TITLE
[chore] 移除 Tailwind CSS 的 `--watch` 參數以適應伺服器環境

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "node build.js",
     "dev": "node build.js --watch",
-    "css": "npx tailwindcss -i ./frontend/styles/app.css -o ./static/styles/app.css --watch"
+    "css": "npx tailwindcss -i ./frontend/styles/app.css -o ./static/styles/app.css"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
### 描述

#### 📌 修改內容：

1. **移除 `--watch` 模式：**
   - 原先在執行 `npx tailwindcss` 指令時使用了 `--watch`，該參數會持續監聽檔案變更。
   - 由於伺服器環境通常不適合持續監控檔案，已移除 `--watch` 參數，改為單次編譯。

---

#### ✅ 測試與驗證：

- 已在本地環境測試，單次編譯能正常完成。
- 確保 CSS 正常生成且樣式無誤。
- 已測試在伺服器環境下部署，無多餘的監聽進程。

---

#### 🎯 預期影響：

- 提升了伺服器環境的穩定性，避免了因長時間持續監控導致的資源浪費。
- 更符合伺服器環境的編譯需求，降低潛在風險。
- 保持前端樣式生成流程的簡潔與可維護性。