### PR TITLE
[fix] 調整搜尋結果頁面

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -27,9 +27,9 @@ ALLOWED_HOSTS = [
 ]
 
 CSRF_TRUSTED_ORIGINS = [
-    'https://trico.zeabur.app',  
-    'http://127.0.0.1:8000',
-    f"https://{env('HOSTNAME')}"
+    "https://trico.zeabur.app",
+    "http://127.0.0.1:8000",
+    f"https://{env('HOSTNAME', default='localhost')}",
 ]
 
 
@@ -249,9 +249,6 @@ DEFAULT_FROM_EMAIL = "三合平台 <selinafs880504@gmail.com>"
 # 替換 `DEFAULT_DOMAIN` 和 `PROTOCOL` 為您的開發環境
 DEFAULT_DOMAIN = os.getenv("DEFAULT_DOMAIN")  # 本地開發使用
 PROTOCOL = os.getenv("PROTOCOL", "http")  # 開發環境使用 http，生產使用 https
-
-
-
 
 
 line_pay_hostname = env('HOSTNAME')

--- a/search/templates/search.html
+++ b/search/templates/search.html
@@ -2,76 +2,66 @@
 {% block content %}
 <div class="main flex flex-col justify-center items-center min-h-screen bg-gray-100 p-6">
   <div class="search-results w-full max-w-4xl bg-white shadow-lg rounded-lg p-8">
-      {% if query %}
-      <h2 class="text-3xl font-semibold text-gray-800 text-center mb-6">
-          搜尋結果：<span class="text-blue-500 font-bold">{{ query }}</span>
-      </h2>
-      {% if results %}
-      <p class="text-lg text-gray-600 text-center mb-4">
-          找到 {{ results|length }} 筆相關結果：
+    {% if query %}
+    <h2 class="text-3xl font-semibold text-gray-800 text-center mb-6">
+      搜尋結果：<span class="text-blue-500 font-bold">{{ query }}</span>
+    </h2>
+    {% if results %}
+    <p class="text-lg text-gray-600 text-center mb-4">
+      找到 {{ results|length }} 筆相關結果：
+    </p>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      {% for result in results %}
+      <!-- 單個服務卡牌 -->
+      <a href="{% url 'services:service_detail' id=result.freelancer_user.id service_id=result.id %}" class="block">
+        <div class="item overflow-hidden transition-transform duration-300 hover:scale-105 rounded-lg">
+          <!-- 服務圖片 -->
+          <div class="w-full aspect-square bg-gray-200 rounded-lg overflow-hidden">
+            <img class="w-full h-full object-cover" 
+                 src="{% if result.photo %}{{ result.photo.url }}{% else %}https://fakeimg.pl/300{% endif %}" 
+                 alt="{{ result.title }}" />
+          </div>
+          <div class="p-4">
+            <!-- 接案者頭像與名稱 -->
+            <div class="flex items-center mb-3">
+              <img class="avatarInpage w-10 h-10 rounded-full border border-gray-300 shadow-sm transition duration-300 hover:scale-110" 
+                   src="{% if result.freelancer_user.profile.photo %}{{ result.freelancer_user.profile.photo.url }}{% else %}https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp{% endif %}" 
+                   alt="User Avatar" />
+              <p class="ml-3 text-sm font-semibold text-gray-700">{{ result.freelancer_user.username }}</p>
+            </div>
+            <!-- 服務標題 -->
+            <p class="text-gray-800 font-medium truncate" title="{{ result.title }}">
+              {{ result.title }}
+            </p>
+            <!-- 服務描述 -->
+            <p class="mt-2 text-gray-600 text-sm">
+              {{ result.description|truncatewords:25 }}
+            </p>
+            <!-- 費用 -->
+            <p class="mt-2 text-sm font-semibold text-gray-800">
+              費用 $ {{ result.standard_price|default:"-" }} 起
+            </p>
+          </div>
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+    {% else %}
+    <div class="no-results text-center mt-8">
+      <p class="text-lg text-gray-700 font-medium mb-4">
+        很抱歉，沒有找到與「<span class="text-red-500 font-semibold">{{ query }}</span>」相關的結果。
       </p>
-      <ul class="results-list space-y-6">
-        {% for result in results %}
-        <li class="result-item bg-gray-50 p-6 rounded-lg border hover:shadow-md transition">
-            <a href="{% url 'service_detail' pk=result.id %}" class="text-xl font-bold text-blue-600 hover:underline">
-                {{ result.title }}
-            </a>
-            <p class="text-sm text-gray-500 mt-2">發佈日期：{{ result.created_at|date:"Y-m-d" }}</p>
-        </li>
-        {% endfor %}
+      <p class="text-gray-600 mb-4">您可以嘗試以下方法：</p>
+      <ul class="text-left inline-block space-y-2">
+        <li class="text-gray-600"><span class="font-semibold">✔️</span> 檢查關鍵字拼寫是否正確</li>
+        <li class="text-gray-600"><span class="font-semibold">✔️</span> 嘗試使用其他關鍵字</li>
+        <li class="text-gray-600"><span class="font-semibold">✔️</span> 縮短或簡化您的搜尋條件</li>
       </ul>
-      {% else %}
-      <div class="no-results text-center mt-8">
-          <p class="text-lg text-gray-700 font-medium mb-4">
-              很抱歉，沒有找到與「<span class="text-red-500 font-semibold">{{ query }}</span>」相關的結果。
-          </p>
-          <p class="text-gray-600 mb-4">您可以嘗試以下方法：</p>
-          <ul class="text-left inline-block space-y-2">
-              <li class="text-gray-600"><span class="font-semibold">✔️</span> 檢查關鍵字拼寫是否正確</li>
-              <li class="text-gray-600"><span class="font-semibold">✔️</span> 嘗試使用其他關鍵字</li>
-              <li class="text-gray-600"><span class="font-semibold">✔️</span> 縮短或簡化您的搜尋條件</li>
-          </ul>
-      </div>
-      {% endif %}
-      {% else %}
-      <p class="text-center text-gray-600 mt-6">請輸入搜尋關鍵字以查看結果。</p>
-      {% endif %}
+    </div>
+    {% endif %}
+    {% else %}
+    <p class="text-center text-gray-600 mt-6">請輸入搜尋關鍵字以查看結果。</p>
+    {% endif %}
   </div>
 </div>
 {% endblock %}
-
-
-<!-- <div class="search-results">
-  {% if query %}
-  <h2>搜尋結果：<span class="query-highlight">{{ query }}</span></h2>
-  {% if results %}
-  <p>找到 {{ results|length }} 筆相關結果：</p>
-  <ul class="results-list">
-    {% for search in results %}
-    <li class="result-item">
-      <a href="{{ search.get_absolute_url }}" class="result-title"
-        >{{ search.title }}</a
-      >
-      <span class="result-date"
-        >發布日期：{{ search.created_at|date:"Y-m-d" }}</span
-      >
-    </li>
-    {% endfor %}
-  </ul>
-  {% else %}
-  <div class="no-results">
-    <p>
-      很抱歉，沒有找到與「<span class="query-highlight">{{ query }}</span
-      >」相關的結果。
-    </p>
-    <p>您可以嘗試以下方法：</p>
-    <ul>
-      <li>檢查關鍵字拼寫是否正確</li>
-      <li>嘗試使用其他關鍵字</li>
-      <li>縮短或簡化您的搜尋條件</li>
-    </ul>
-  </div>
-  {% endif %} {% else %}
-  <p>請輸入搜尋關鍵字以查看結果。</p>
-  {% endif %}
-</div> -->

--- a/search/urls.py
+++ b/search/urls.py
@@ -2,6 +2,5 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("search", views.search_view, name="search"), 
-    path("service/<int:pk>/", views.service_detail_view, name="service_detail")
+    path("search", views.search_view, name="search"),
 ]

--- a/search/views.py
+++ b/search/views.py
@@ -18,9 +18,16 @@ def search_view(request):
         if form.is_valid():
             query = form.cleaned_data["keyword"]
             # 過濾標題或內容中包含關鍵字的結果
-            results = Service.objects.filter(
-                Q(title__icontains=query) | Q(description__icontains=query)
-            ).all()  # 確保獲取所有結果
+            results = (
+                Service.objects.filter(
+                    Q(title__icontains=query)
+                    | Q(description__icontains=query)
+                    | Q(standard_description__icontains=query)
+                    | Q(premium_description__icontains=query)
+                )
+                .select_related("freelancer_user")
+                .all()
+            )  # 優化載入關聯用戶
     else:
         form = SearchForm()
 

--- a/templates/shared/navbar.html
+++ b/templates/shared/navbar.html
@@ -16,17 +16,20 @@
     <div class="relative flex items-center w-full max-w-xl">
       <!-- prettier-ignore -->
       <form action="{% url 'search' %}" method="get" class="relative flex items-center w-full max-w-xl">
-      <!-- 搜尋框 -->
-      <input type="text" name="keyword" placeholder="請輸入關鍵字..." class="w-full py-2 pl-4 pr-4 text-gray-700 bg-white border border-gray-300 rounded-l-lg focus:outline-none focus:ring-2 focus:ring-gray-100"/>
-       <!-- 按鈕 -->
-      <button type="submit" class="px-4 py-2 font-semibold text-white bg-blue-500 rounded-r-lg hover:bg-sky-700">
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-        </svg>
-      </button>
-      <div class="absolute text-gray-400 transform -translate-y-1/2 left-3 top-1/2">
-      </div>
-    </form>
+  <input 
+    type="text" 
+    name="keyword" 
+    placeholder="請輸入關鍵字..." 
+    class="w-full py-2 pl-4 pr-4 text-gray-700 bg-white border border-gray-300 rounded-l-lg focus:outline-none focus:ring-2 focus:ring-gray-100">
+  <button 
+    type="submit" 
+    class="px-4 py-2 font-semibold text-white bg-blue-500 rounded-r-lg hover:bg-sky-700">
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="11" cy="11" r="8"></circle>
+      <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+    </svg>
+  </button>
+</form>
     </div>
   </div>
   {% endif %}


### PR DESCRIPTION
修正搜尋頁面導入服務詳情頁面的正確路徑，並新增用戶可點擊愛心及留言的功能。





<img width="1020" alt="截圖 2025-01-11 12 09 49" src="https://github.com/user-attachments/assets/c53e77cf-6e21-4191-869d-44986773d1b0" />






同時，搜尋結果頁面可顯示服務的標題、圖片及內容。




<img width="464" alt="截圖 2025-01-11 15 40 05" src="https://github.com/user-attachments/assets/6aad79a5-632b-4a38-8eda-de4ae3a9c81a" />

<img width="309" alt="截圖 2025-01-11 15 45 53" src="https://github.com/user-attachments/assets/8526ae0d-6649-4214-85a0-eb22ad1434b6" />




